### PR TITLE
CreateCSR using boringssl api (#57)

### DIFF
--- a/contrib/sgx/private_key_providers/source/sgx.h
+++ b/contrib/sgx/private_key_providers/source/sgx.h
@@ -10,12 +10,18 @@
 #include "envoy/common/pure.h"
 #include "envoy/singleton/manager.h"
 
+#include "source/common/common/base64.h"
 #include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
 
 #include "contrib/sgx/private_key_providers/source/utility.h"
+#include "openssl/ec.h"
+#include "openssl/evp.h"
+#include "openssl/pem.h"
 #include "openssl/rsa.h"
 #include "openssl/ssl.h"
+#include "openssl/x509.h"
+#include "openssl/x509v3.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -35,8 +41,9 @@ const int defaultRSAKeySize = 3072;
 const int maxTokenLabelSize = 32;
 const int maxKeyLabelSize = 32;
 const int maxSignatureSize = 2048;
-const std::string osslCsrCmd =
-    "OPENSSL_CONF=/etc/sgx/pkcs11.conf openssl req -new -engine pkcs11 -keyform engine -sha256";
+const std::string CA = "CA:FALSE";
+const std::string keyUsage = "Digital Signature,Non Repudiation,Key Encipherment";
+const std::string extKeyUsage = "TLS Web Client Authentication, TLS Web Server Authentication";
 
 struct ByteString {
   CK_ULONG byte_size;
@@ -70,18 +77,15 @@ public:
   CK_RV findKeyPair(CK_OBJECT_HANDLE_PTR private_key, CK_OBJECT_HANDLE_PTR pubkey,
                     std::string& key_label, CK_ULONG& object_count, bool verbose = true);
 
-  //  CK_RV deleteKeyPair(std::string &key_label);
-
   CK_RV rsaSign(CK_OBJECT_HANDLE private_key, CK_OBJECT_HANDLE pubkey, bool is_pss, int hash,
                 const uint8_t* in, size_t in_len, ByteString* signature);
 
   CK_RV rsaDecrypt(CK_OBJECT_HANDLE private_key, const uint8_t* in, size_t in_len,
                    ByteString* decrypted);
 
-  //  CK_RV rsaEncrypt(CK_OBJECT_HANDLE pubkey, const uint8_t *in, size_t inlen, ByteString
-  //  *encrypted);
-
-  CK_RV createCSR(std::string& subj, std::string& key_label, std::string& out) const;
+  CK_RV createCSR(bool isrsa, CK_OBJECT_HANDLE pubkey, CK_OBJECT_HANDLE privkey,
+                  std::string& csr_config, std::string& quote, std::string& quote_key,
+                  std::string& quotepub, std::string& quotepub_key, std::string& out);
 
   CK_RV createQuote(CK_OBJECT_HANDLE pubkey, ByteString* quote, ByteString* quote_pub);
 
@@ -91,6 +95,10 @@ public:
 
   CK_RV ecdsaSign(CK_OBJECT_HANDLE private_key, CK_OBJECT_HANDLE pubkey, const uint8_t* in,
                   size_t in_len, ByteString* signature);
+
+  CK_RV getRSAPublicKey(CK_OBJECT_HANDLE pubkey, ByteString* modules, ByteString* exponent);
+
+  CK_RV getECDSAPublicKey(CK_OBJECT_HANDLE pubkey, ByteString* group, ByteString* points);
 
 private:
   Thread::MutexBasicLockable lock_{};
@@ -106,9 +114,16 @@ private:
 
   static void logQuote(CK_BYTE_PTR bytes);
 
-  // CK_RV generatequote();
-
   static CK_RV allocAndCopyBytes(CK_BYTE_PTR* dest, CK_BYTE_PTR src, CK_ULONG size);
+
+  void addExt(STACK_OF(X509_EXTENSION) * exts, int nid, const char* subvalue);
+
+  unsigned long longVal(const ByteString& byteString);
+
+  ByteString octet2Raw(const ByteString& byteString);
+
+  int calculateDigest(const EVP_MD* md, const uint8_t* in, size_t in_len, unsigned char* hash,
+                      unsigned int* hash_len);
 
   std::string libpath_;
   std::string tokenlabel_;
@@ -117,16 +132,9 @@ private:
   CK_SLOT_ID slotid_;
   CK_SESSION_HANDLE sessionhandle_;
   CK_FUNCTION_LIST_PTR p11_;
-  //  ByteString *quote_;
-  //  ByteString *quotepub_;
 
   bool initialized_;
 };
-
-// class SgxImpl : public virtual Sgx {
-// public:
-//     std::string name() const { return "sgx"; } ;
-// };
 
 } // namespace Sgx
 } // namespace PrivateKeyMethodProvider

--- a/contrib/sgx/private_key_providers/source/sgx_private_key_provider.h
+++ b/contrib/sgx/private_key_providers/source/sgx_private_key_provider.h
@@ -128,6 +128,7 @@ private:
   std::string quotepub_;
   std::string quote_key_;
   std::string quotepub_key_;
+  std::string csr_;
 
   // related to SGX
   SgxContextSharedPtr sgx_context_;


### PR DESCRIPTION
* generate csr using boringssl api
1. add getRSAPublicKey and getECDSAPublicKey to get key data from CTK.
2. add some necessary methods to decode key data
3. using boringssl api to create csr in CreateCSR

* add san in csr
1. read san(subject altname) from openssl config received from istio
2. insert san into x509_req as v3_req extension
3. change control-plane to use new CreateCSR
4. cleanup comments

* add check and fix comments

* change hard-code to boringssl
1. change to use boringssl api
2. clean hard-code

* tls: update BoringSSL to b9512430(5195) (#22805)

Signed-off-by: giantcroc <changran.wang@intel.com>

Signed-off-by: giantcroc <changran.wang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
