### PR TITLE
Add mocks support for TLS bumping/splicing API changes.

### DIFF
--- a/api/envoy/extensions/filters/network/bumping/v3/bumping.proto
+++ b/api/envoy/extensions/filters/network/bumping/v3/bumping.proto
@@ -40,4 +40,3 @@ message Bumping {
   // Certificate provider instance for fetching TLS certificates.
   transport_sockets.tls.v3.CertificateProviderPluginInstance tls_certificate_provider_instance = 5;
 }
-

--- a/contrib/transport_sockets/tls/cert_validator/extension/source/extension_validator.cc
+++ b/contrib/transport_sockets/tls/cert_validator/extension/source/extension_validator.cc
@@ -93,8 +93,8 @@ int ExtensionValidator::doSynchronousVerifyCertChain(
   ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::connection), info,
                       "The customized certificate extension has been verified");
 
-  return default_cert_validator_->doSynchronousVerifyCertChain(store_ctx, ssl_extended_info, leaf_cert,
-                                                    transport_socket_options);
+  return default_cert_validator_->doSynchronousVerifyCertChain(store_ctx, ssl_extended_info,
+                                                               leaf_cert, transport_socket_options);
 }
 
 absl::optional<uint32_t> ExtensionValidator::daysUntilFirstCertExpires() const {

--- a/contrib/transport_sockets/tls/cert_validator/extension/source/extension_validator.h
+++ b/contrib/transport_sockets/tls/cert_validator/extension/source/extension_validator.h
@@ -38,9 +38,9 @@ public:
   // Tls::CertValidator
   void addClientValidationContext(SSL_CTX* context, bool require_client_cert) override;
 
-  int doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
-                        X509& leaf_cert,
-                        const Network::TransportSocketOptions* transport_socket_options) override;
+  int doSynchronousVerifyCertChain(
+      X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info, X509& leaf_cert,
+      const Network::TransportSocketOptions* transport_socket_options) override;
 
   int initializeSslContexts(std::vector<SSL_CTX*> contexts, bool provides_certificates) override;
 

--- a/source/extensions/filters/network/bumping/BUILD
+++ b/source/extensions/filters/network/bumping/BUILD
@@ -23,8 +23,8 @@ envoy_cc_library(
     deps = [
         "//envoy/access_log:access_log_interface",
         "//envoy/buffer:buffer_interface",
-        "//envoy/common:time_interface",
         "//envoy/certificate_provider:certificate_provider_interface",
+        "//envoy/common:time_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
@@ -47,8 +47,8 @@ envoy_cc_library(
         "//source/common/http:codec_client_lib",
         "//source/common/network:application_protocol_lib",
         "//source/common/network:cidr_range_lib",
-        "//source/common/network:filter_lib",
         "//source/common/network:connection_impl",
+        "//source/common/network:filter_lib",
         "//source/common/network:proxy_protocol_filter_state_lib",
         "//source/common/network:socket_option_factory_lib",
         "//source/common/network:transport_socket_options_lib",
@@ -77,4 +77,3 @@ envoy_cc_extension(
         "@envoy_api//envoy/extensions/filters/network/bumping/v3:pkg_cc_proto",
     ],
 )
-

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -46,10 +46,13 @@ static void errorCallbackTest(Address::IpVersion version) {
   client_connection->connect();
 
   StreamInfo::StreamInfoImpl stream_info(dispatcher->timeSource(), nullptr);
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory =
+      Network::Test::createRawBufferDownstreamSocketFactory();
   EXPECT_CALL(listener_callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
         Network::ConnectionPtr conn = dispatcher->createServerConnection(
-            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info);
+            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info,
+            *factory);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         socket->close();
@@ -105,11 +108,14 @@ TEST_P(TcpListenerImplTest, UseActualDst) {
   EXPECT_CALL(listener, getLocalAddress(_)).Times(0);
 
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource(), nullptr);
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory =
+      Network::Test::createRawBufferDownstreamSocketFactory();
   EXPECT_CALL(listener_callbacks2, onAccept_(_)).Times(0);
   EXPECT_CALL(listener_callbacks1, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
         Network::ConnectionPtr conn = dispatcher_->createServerConnection(
-            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info);
+            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info,
+            *factory);
         EXPECT_EQ(*conn->connectionInfoProvider().localAddress(),
                   *socket->connectionInfoProvider().localAddress());
         client_connection->close(ConnectionCloseType::NoFlush);
@@ -134,10 +140,13 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitEnforcement) {
   std::vector<Network::ClientConnectionPtr> client_connections;
   std::vector<Network::ConnectionPtr> server_connections;
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource(), nullptr);
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory =
+      Network::Test::createRawBufferDownstreamSocketFactory();
   EXPECT_CALL(listener_callbacks, onAccept_(_))
       .WillRepeatedly(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
         server_connections.emplace_back(dispatcher_->createServerConnection(
-            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info));
+            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info,
+            *factory));
         dispatcher_->exit();
       }));
 
@@ -199,10 +208,13 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitListenerOptOut) {
   std::vector<Network::ClientConnectionPtr> client_connections;
   std::vector<Network::ConnectionPtr> server_connections;
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource(), nullptr);
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory =
+      Network::Test::createRawBufferDownstreamSocketFactory();
   EXPECT_CALL(listener_callbacks, onAccept_(_))
       .WillRepeatedly(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
         server_connections.emplace_back(dispatcher_->createServerConnection(
-            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info));
+            std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info,
+            *factory));
         dispatcher_->exit();
       }));
 
@@ -251,10 +263,12 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
   client_connection->connect();
 
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource(), nullptr);
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory =
+      Network::Test::createRawBufferDownstreamSocketFactory();
   EXPECT_CALL(listener_callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::ConnectionPtr conn = dispatcher_->createServerConnection(
-            std::move(socket), Network::Test::createRawBufferSocket(), stream_info);
+            std::move(socket), Network::Test::createRawBufferSocket(), stream_info, *factory);
         EXPECT_EQ(*conn->connectionInfoProvider().localAddress(), *local_dst_address);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
@@ -299,10 +313,12 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
   client_connection->connect();
 
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource(), nullptr);
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory =
+      Network::Test::createRawBufferDownstreamSocketFactory();
   EXPECT_CALL(listener_callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::ConnectionPtr conn = dispatcher_->createServerConnection(
-            std::move(socket), Network::Test::createRawBufferSocket(), stream_info);
+            std::move(socket), Network::Test::createRawBufferSocket(), stream_info, *factory);
         EXPECT_EQ(conn->connectionInfoProvider().localAddress()->ip()->version(),
                   conn->connectionInfoProvider().remoteAddress()->ip()->version());
         EXPECT_EQ(conn->connectionInfoProvider().localAddress()->asString(),

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -130,11 +130,13 @@ TEST_F(SecretManagerImplTest, CertificateValidationContextSecretLoadSuccess) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl(config_tracker_));
   secret_manager->addStaticSecret(secret_config);
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> ctx;
 
   ASSERT_EQ(secret_manager->findStaticCertificateValidationContextProvider("undefined"), nullptr);
   ASSERT_NE(secret_manager->findStaticCertificateValidationContextProvider("abc.com"), nullptr);
   Ssl::CertificateValidationContextConfigImpl cvc_config(
-      *secret_manager->findStaticCertificateValidationContextProvider("abc.com")->secret(), *api_);
+      *secret_manager->findStaticCertificateValidationContextProvider("abc.com")->secret(), *api_,
+      ctx);
   const std::string cert_pem =
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
@@ -527,10 +529,11 @@ validation_context:
   const auto decoded_resources_2 = TestUtility::decodeResources({typed_secret});
 
   init_target_handle->initialize(init_watcher);
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> ctx;
   secret_context.cluster_manager_.subscription_factory_.callbacks_->onConfigUpdate(
       decoded_resources_2.refvec_, "validation-context-v1");
   Ssl::CertificateValidationContextConfigImpl cert_validation_context(
-      *context_secret_provider->secret(), *api_);
+      *context_secret_provider->secret(), *api_, ctx);
   EXPECT_EQ("DUMMY_INLINE_STRING_TRUSTED_CA", cert_validation_context.caCert());
   const std::string updated_config_dump = R"EOF(
 dynamic_active_secrets:
@@ -1145,11 +1148,13 @@ TEST_F(SecretManagerImplTest, DeprecatedSanMatcher) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl(config_tracker_));
   secret_manager->addStaticSecret(secret_config);
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> ctx;
 
   ASSERT_EQ(secret_manager->findStaticCertificateValidationContextProvider("undefined"), nullptr);
   ASSERT_NE(secret_manager->findStaticCertificateValidationContextProvider("abc.com"), nullptr);
   Ssl::CertificateValidationContextConfigImpl cvc_config(
-      *secret_manager->findStaticCertificateValidationContextProvider("abc.com")->secret(), *api_);
+      *secret_manager->findStaticCertificateValidationContextProvider("abc.com")->secret(), *api_,
+      ctx);
   EXPECT_EQ(cvc_config.subjectAltNameMatchers().size(), 4);
   EXPECT_EQ("example.foo", cvc_config.subjectAltNameMatchers()[0].matcher().exact());
   EXPECT_EQ(envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::DNS,

--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -115,6 +115,9 @@ public:
 
   Secret::SecretManager& secretManager() override { return secret_manager_; }
   Singleton::Manager& singletonManager() override { return singleton_manager_; }
+  CertificateProvider::CertificateProviderManager& certificateProviderManager() override {
+    return certificate_provider_manager_;
+  }
 
   MOCK_METHOD(ClusterManager*, clusterManagerFromProto_,
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
@@ -141,6 +144,7 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Server::MockAdmin> admin_;
   NiceMock<Secret::MockSecretManager> secret_manager_;
+  NiceMock<CertificateProvider::MockCertificateProviderManager> certificate_provider_manager_;
   NiceMock<AccessLog::MockAccessLogManager> log_manager_;
   Singleton::ManagerImpl singleton_manager_{Thread::threadFactoryForTest()};
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -337,7 +337,8 @@ private:
 class TestDnsServer : public TcpListenerCallbacks {
 public:
   TestDnsServer(Event::Dispatcher& dispatcher)
-      : dispatcher_(dispatcher), record_ttl_(0), stream_info_(dispatcher.timeSource(), nullptr) {}
+      : dispatcher_(dispatcher), record_ttl_(0), stream_info_(dispatcher.timeSource(), nullptr),
+        factory_(Network::Test::createRawBufferDownstreamSocketFactory()) {}
 
   void onAccept(ConnectionSocketPtr&& socket) override {
     Network::ConnectionPtr new_connection = dispatcher_.createServerConnection(
@@ -381,6 +382,7 @@ private:
   // over.
   std::vector<std::unique_ptr<TestDnsServerQuery>> queries_;
   StreamInfo::StreamInfoImpl stream_info_;
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory_;
 };
 
 } // namespace

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -386,8 +386,8 @@ void testUtil(const TestUtilOptions& options) {
         // configureInitialCongestionWindow is an unimplemented empty function, this is just to
         // increase code coverage.
         ssl_socket->configureInitialCongestionWindow(100, std::chrono::microseconds(123));
-        server_connection = dispatcher->createServerConnection(std::move(socket),
-                                                               std::move(ssl_socket), stream_info);
+        server_connection = dispatcher->createServerConnection(
+            std::move(socket), std::move(ssl_socket), stream_info, server_ssl_socket_factory);
         server_connection->addConnectionCallbacks(server_connection_callbacks);
       }));
 
@@ -4003,7 +4003,11 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
                 ? server_ssl_socket_factory
                 : server2_ssl_socket_factory;
         server_connection = dispatcher_->createServerConnection(
-            std::move(accepted_socket), tsf.createDownstreamTransportSocket(), stream_info_);
+            std::move(accepted_socket), tsf.createDownstreamTransportSocket(), stream_info_,
+            accepted_socket->connectionInfoProvider().localAddress() ==
+                    socket->connectionInfoProvider().localAddress()
+                ? server_ssl_socket_factory
+                : server2_ssl_socket_factory);
         server_connection->addConnectionCallbacks(server_connection_callbacks);
       }));
 

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -43,8 +43,8 @@ public:
   }
   Network::ServerConnectionPtr
   createServerConnection(Network::ConnectionSocketPtr&& socket,
-                         Network::TransportSocketPtr&& transport_socket,
-                         StreamInfo::StreamInfo&) override {
+                         Network::TransportSocketPtr&& transport_socket, StreamInfo::StreamInfo&,
+                         const Network::DownstreamTransportSocketFactory&) override {
     // The caller expects both the socket and the transport socket to be moved.
     socket.reset();
     transport_socket.reset();

--- a/test/mocks/event/wrapped_dispatcher.h
+++ b/test/mocks/event/wrapped_dispatcher.h
@@ -15,7 +15,8 @@ namespace Event {
 // override the behavior of a few.
 class WrappedDispatcher : public Dispatcher {
 public:
-  WrappedDispatcher(Dispatcher& impl) : impl_(impl) {}
+  WrappedDispatcher(Dispatcher& impl)
+      : impl_(impl), factory_(Network::Test::createRawBufferDownstreamSocketFactory()) {}
 
   // Event::Dispatcher
   const std::string& name() override { return impl_.name(); }
@@ -37,8 +38,8 @@ public:
   createServerConnection(Network::ConnectionSocketPtr&& socket,
                          Network::TransportSocketPtr&& transport_socket,
                          StreamInfo::StreamInfo& stream_info) override {
-    return impl_.createServerConnection(std::move(socket), std::move(transport_socket),
-                                        stream_info);
+    return impl_.createServerConnection(std::move(socket), std::move(transport_socket), stream_info,
+                                        *factory_);
   }
 
   Network::ClientConnectionPtr createClientConnection(
@@ -127,6 +128,7 @@ public:
 
 protected:
   Dispatcher& impl_;
+  Envoy::Network::DownstreamTransportSocketFactoryPtr factory_;
 };
 
 } // namespace Event

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -241,6 +241,7 @@ envoy_cc_mock(
     hdrs = ["transport_socket_factory_context.h"],
     deps = [
         "//envoy/server:tracer_config_interface",
+        "//source/common/certificate_provider:certificate_provider_manager_impl_lib",
         "//source/common/secret:secret_manager_impl_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/api:api_mocks",

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -51,6 +51,8 @@ MockInstance::MockInstance()
   ON_CALL(*this, transportSocketFactoryContext())
       .WillByDefault(ReturnRef(*transport_socket_factory_context_));
   ON_CALL(*this, enableReusePortDefault()).WillByDefault(Return(true));
+  ON_CALL(*this, certificateProviderManager())
+      .WillByDefault(ReturnRef(certificate_provider_manager_));
 }
 
 MockInstance::~MockInstance() = default;

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -89,6 +89,7 @@ public:
   MOCK_METHOD(Configuration::TransportSocketFactoryContext&, transportSocketFactoryContext, ());
   MOCK_METHOD(bool, enableReusePortDefault, ());
   MOCK_METHOD(void, setSinkPredicates, (std::unique_ptr<Envoy::Stats::SinkPredicates> &&));
+  MOCK_METHOD(CertificateProvider::CertificateProviderManager&, certificateProviderManager, ());
 
   void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) override {
     http_context_.setDefaultTracingConfig(tracing_config);
@@ -132,6 +133,8 @@ public:
       server_factory_context_;
   std::shared_ptr<testing::NiceMock<Configuration::MockTransportSocketFactoryContext>>
       transport_socket_factory_context_;
+  testing::NiceMock<CertificateProvider::MockCertificateProviderManager>
+      certificate_provider_manager_;
 };
 
 namespace Configuration {

--- a/test/mocks/server/transport_socket_factory_context.cc
+++ b/test/mocks/server/transport_socket_factory_context.cc
@@ -13,7 +13,7 @@ using ::testing::ReturnRef;
 
 MockTransportSocketFactoryContext::MockTransportSocketFactoryContext()
     : secret_manager_(std::make_unique<Secret::SecretManagerImpl>(config_tracker_)),
-      singleton_manager_(Thread::threadFactoryForTest()) {
+      singleton_manager_(Thread::threadFactoryForTest()), certificate_provider_manager_(api_) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
   ON_CALL(*this, messageValidationVisitor())
@@ -23,6 +23,8 @@ MockTransportSocketFactoryContext::MockTransportSocketFactoryContext()
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
   ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(singleton_manager_));
+  ON_CALL(*this, certificateProviderManager())
+      .WillByDefault(ReturnRef(certificate_provider_manager_));
 }
 
 MockTransportSocketFactoryContext::~MockTransportSocketFactoryContext() = default;

--- a/test/mocks/server/transport_socket_factory_context.h
+++ b/test/mocks/server/transport_socket_factory_context.h
@@ -2,6 +2,7 @@
 
 #include "envoy/server/transport_socket_config.h"
 
+#include "source/common/certificate_provider/certificate_provider_manager_impl.h"
 #include "source/common/secret/secret_manager_impl.h"
 
 #include "test/mocks/access_log/mocks.h"
@@ -39,6 +40,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, ());
+  MOCK_METHOD(CertificateProvider::CertificateProviderManager&, certificateProviderManager, ());
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Api::MockApi> api_;
@@ -49,6 +51,7 @@ public:
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
   Singleton::ManagerImpl singleton_manager_;
+  CertificateProvider::CertificateProviderManagerImpl certificate_provider_manager_;
 };
 } // namespace Configuration
 } // namespace Server

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -22,6 +22,8 @@ MockClientContextConfig::MockClientContextConfig() {
   ON_CALL(*this, tlsKeyLogLocal()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogRemote()).WillByDefault(testing::ReturnRef(iplist_));
   ON_CALL(*this, tlsKeyLogPath()).WillByDefault(testing::ReturnRef(path_));
+  ON_CALL(*this, certProviderCaps())
+      .WillByDefault(testing::Return(certificate_provider_capabilities_));
 }
 MockClientContextConfig::~MockClientContextConfig() = default;
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <gmock/gmock-function-mocker.h>
+
 #include <functional>
 #include <string>
 
@@ -104,6 +106,8 @@ public:
   MOCK_METHOD(const Network::Address::IpList&, tlsKeyLogRemote, (), (const));
   MOCK_METHOD(const std::string&, tlsKeyLogPath, (), (const));
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), (const));
+  MOCK_METHOD(CertificateProvider::CertificateProvider::Capabilities, certProviderCaps, (),
+              (const));
   Ssl::HandshakerCapabilities capabilities_;
   std::string sni_{"default_sni.example.com"};
   std::string ciphers_{"RSA"};
@@ -111,6 +115,7 @@ public:
   std::string test_{};
   Network::Address::IpList iplist_;
   std::string path_{};
+  CertificateProvider::CertificateProvider::Capabilities certificate_provider_capabilities_;
 };
 
 class MockServerContextConfig : public ServerContextConfig {
@@ -182,6 +187,7 @@ public:
               trustChainVerification, (), (const));
   MOCK_METHOD(bool, onlyVerifyLeafCertificateCrl, (), (const));
   MOCK_METHOD(absl::optional<uint32_t>, maxVerifyDepth, (), (const));
+  MOCK_METHOD(Envoy::CertificateProvider::CertificateProviderSharedPtr, caProvider, (), (const));
 };
 
 class MockPrivateKeyMethodManager : public PrivateKeyMethodManager {

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -237,6 +237,7 @@ envoy_cc_mock(
     srcs = ["cluster_manager_factory.cc"],
     hdrs = ["cluster_manager_factory.h"],
     deps = [
+        "//envoy/certificate_provider:certificate_provider_manager_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//source/common/singleton:manager_impl_lib",
         "//test/mocks/secret:secret_mocks",

--- a/test/mocks/upstream/cluster_manager_factory.cc
+++ b/test/mocks/upstream/cluster_manager_factory.cc
@@ -1,6 +1,11 @@
 #include "cluster_manager_factory.h"
 
 namespace Envoy {
+namespace CertificateProvider {
+MockCertificateProviderManager::MockCertificateProviderManager() = default;
+
+MockCertificateProviderManager::~MockCertificateProviderManager() = default;
+} // namespace CertificateProvider
 namespace Upstream {
 MockClusterManagerFactory::MockClusterManagerFactory() = default;
 

--- a/test/mocks/upstream/cluster_manager_factory.h
+++ b/test/mocks/upstream/cluster_manager_factory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/certificate_provider/certificate_provider_manager.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "source/common/singleton/manager_impl.h"
@@ -10,9 +11,24 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
-namespace Upstream {
 using ::testing::NiceMock;
+
+namespace Envoy {
+namespace CertificateProvider {
+class MockCertificateProviderManager : public CertificateProviderManager {
+public:
+  MockCertificateProviderManager();
+  ~MockCertificateProviderManager() override;
+
+  MOCK_METHOD(void, addCertificateProvider,
+              (absl::string_view name, const envoy::config::core::v3::TypedExtensionConfig& config,
+               Server::Configuration::TransportSocketFactoryContext& factory_context));
+
+  MOCK_METHOD(CertificateProviderSharedPtr, getCertificateProvider, (absl::string_view name));
+};
+} // namespace CertificateProvider
+
+namespace Upstream {
 class MockClusterManagerFactory : public ClusterManagerFactory {
 public:
   MockClusterManagerFactory();
@@ -20,6 +36,9 @@ public:
 
   Secret::MockSecretManager& secretManager() override { return secret_manager_; };
   Singleton::Manager& singletonManager() override { return singleton_manager_; }
+  CertificateProvider::CertificateProviderManager& certificateProviderManager() override {
+    return certificate_provider_manager_;
+  }
 
   MOCK_METHOD(ClusterManagerPtr, clusterManagerFromProto,
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
@@ -50,6 +69,7 @@ public:
 private:
   NiceMock<Secret::MockSecretManager> secret_manager_;
   Singleton::ManagerImpl singleton_manager_{Thread::threadFactoryForTest()};
+  NiceMock<CertificateProvider::MockCertificateProviderManager> certificate_provider_manager_;
 };
 } // namespace Upstream
 } // namespace Envoy

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -50,11 +50,13 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
   AccessLog::MockAccessLogManager log_manager;
   Singleton::ManagerImpl singleton_manager{Thread::threadFactoryForTest()};
   NiceMock<Server::MockInstance> server;
+  NiceMock<CertificateProvider::MockCertificateProviderManager> certificate_provider_manager;
 
   ValidationClusterManagerFactory factory(
       admin, runtime, stats_store, tls, dns_resolver, ssl_context_manager, dispatcher, local_info,
       secret_manager, validation_context, *api, http_context, grpc_context, router_context,
-      log_manager, singleton_manager, options, quic_stat_names, server);
+      log_manager, singleton_manager, options, quic_stat_names, certificate_provider_manager,
+      server);
 
   const envoy::config::bootstrap::v3::Bootstrap bootstrap;
   ClusterManagerPtr cluster_manager = factory.clusterManagerFromProto(bootstrap);


### PR DESCRIPTION
This commit fixes building of the unit tests. The TLS bumping commit was changing Envoy internal APIs, causing the existing mocks to not compile.