### PR TITLE
Fix QATzip build error with clang.

### DIFF
--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -18,6 +18,11 @@ configure_make(
         "--enable-static",
         "--disable-shared",
     ],
+    copts = [
+        "-Wno-error=newline-eof",
+        "-Wno-error=strict-prototypes",
+        "-Wno-error=unused-but-set-variable",
+    ],
     lib_source = "@com_github_intel_qatzip//:all",
     out_static_libs = [
         "libqatzip.a",

--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -21,6 +21,7 @@ configure_make(
     copts = [
         "-Wno-error=newline-eof",
         "-Wno-error=strict-prototypes",
+        "-Wno-error=unknown-warning-option",
         "-Wno-error=unused-but-set-variable",
     ],
     lib_source = "@com_github_intel_qatzip//:all",


### PR DESCRIPTION
Ignore various warnings-as-errors during QATzip build. A TODO for me is that these should be fixes upstream and the `-Wno-error=` opts removed.
