### PR TITLE
tls: fix handshake failure when both private key provider and cert validation are set

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,9 @@ bug_fixes:
 - area: connection limit
   change: |
     fixed a use-after-free bug in the connection limit filter.
+- area: tls
+  change: |
+    fixed a bug where handshake may fail when both private key provider and cert validation are set.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/envoy/ssl/ssl_socket_extended_info.h
+++ b/envoy/ssl/ssl_socket_extended_info.h
@@ -60,7 +60,6 @@ public:
   virtual ClientValidationStatus certificateValidationStatus() const PURE;
 
   /**
-   * Only called when doing asynchronous cert validation.
    * @return ValidateResultCallbackPtr a callback used to return the validation result.
    */
   virtual ValidateResultCallbackPtr createValidateResultCallback() PURE;
@@ -68,8 +67,9 @@ public:
   /**
    * Called after the cert validation completes either synchronously or asynchronously.
    * @param succeeded true if the validation succeeded.
+   * @param async true if the validation is completed asynchronously.
    */
-  virtual void onCertificateValidationCompleted(bool succeeded) PURE;
+  virtual void onCertificateValidationCompleted(bool succeeded, bool async) PURE;
 
   /**
    * @return ValidateStatus the validation status.

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -520,7 +520,7 @@ ValidationResults ContextImpl::customVerifyCertChain(
   if (result.status != ValidationResults::ValidationStatus::Pending) {
     extended_socket_info->setCertificateValidationStatus(result.detailed_status);
     extended_socket_info->onCertificateValidationCompleted(
-        result.status == ValidationResults::ValidationStatus::Successful);
+        result.status == ValidationResults::ValidationStatus::Successful, false);
   }
   return result;
 }

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -26,7 +26,7 @@ void ValidateResultCallbackImpl::onCertValidationResult(bool succeeded,
   }
   extended_socket_info_->setCertificateValidationStatus(detailed_status);
   extended_socket_info_->setCertificateValidationAlert(tls_alert);
-  extended_socket_info_->onCertificateValidationCompleted(succeeded);
+  extended_socket_info_->onCertificateValidationCompleted(succeeded, true);
 }
 
 SslExtendedSocketInfoImpl::~SslExtendedSocketInfoImpl() {
@@ -44,14 +44,15 @@ Envoy::Ssl::ClientValidationStatus SslExtendedSocketInfoImpl::certificateValidat
   return certificate_validation_status_;
 }
 
-void SslExtendedSocketInfoImpl::onCertificateValidationCompleted(bool succeeded) {
+void SslExtendedSocketInfoImpl::onCertificateValidationCompleted(bool succeeded, bool async) {
   cert_validation_result_ =
       succeeded ? Ssl::ValidateStatus::Successful : Ssl::ValidateStatus::Failed;
   if (cert_validate_result_callback_.has_value()) {
-    // This is an async cert validation.
     cert_validate_result_callback_.reset();
     // Resume handshake.
-    ssl_handshaker_.handshakeCallbacks()->onAsynchronousCertValidationComplete();
+    if (async) {
+      ssl_handshaker_.handshakeCallbacks()->onAsynchronousCertValidationComplete();
+    }
   }
 }
 

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.h
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.h
@@ -59,7 +59,7 @@ public:
   void setCertificateValidationStatus(Envoy::Ssl::ClientValidationStatus validated) override;
   Envoy::Ssl::ClientValidationStatus certificateValidationStatus() const override;
   Ssl::ValidateResultCallbackPtr createValidateResultCallback() override;
-  void onCertificateValidationCompleted(bool succeeded) override;
+  void onCertificateValidationCompleted(bool succeeded, bool async) override;
   Ssl::ValidateStatus certificateValidationResult() const override {
     return cert_validation_result_;
   }

--- a/test/extensions/transport_sockets/tls/cert_validator/test_common.h
+++ b/test/extensions/transport_sockets/tls/cert_validator/test_common.h
@@ -26,7 +26,7 @@ public:
 
   Ssl::ValidateResultCallbackPtr createValidateResultCallback() override { return nullptr; };
 
-  void onCertificateValidationCompleted(bool succeeded) override {
+  void onCertificateValidationCompleted(bool succeeded, bool) override {
     validate_result_ = succeeded ? Ssl::ValidateStatus::Successful : Ssl::ValidateStatus::Failed;
   }
   Ssl::ValidateStatus certificateValidationResult() const override { return validate_result_; }


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: tls: fix handshake failure when both private key provider and cert validation are set
Additional Description:

After #24297, when both private key provider and validation are set, e.g., using Envoy as sidecars, handshake may end with SSL internal error and HTTP 503 will return.

When both private key provider and validation are set, when the private key provider completed its calculation and resumed the handshake (`ssl_do_handshake`), an async cert validation will be triggered. If the custom validation is not provided, then the async cert validation will complete in the sync way and resume the handshake again (`ssl_do_handshake`), which cause the error.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
Fixes commit 55a4cc725f5c2a536aa6afa193839d65d2b1a4cc
