### PR TITLE
ci: support static build

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -501,6 +501,12 @@ case $CI_TARGET in
               "${TEST_TARGETS[@]}"
         ;;
 
+    # build totally static binary
+    dev.contrib.static)
+        setup_clang_toolchain
+        bazel build --linkopt=-static --copt=-static //contrib/exe:envoy-static
+        ;;
+
     distribution)
         echo "Building distro packages..."
         setup_clang_toolchain


### PR DESCRIPTION
Some companies like Bytedance need static binary, but current build always generate dynamic binary, add this target to fix it.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
