### PR TITLE
cryptomb: initialize key type field

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
@@ -187,7 +187,7 @@ private:
   Ssl::BoringSslPrivateKeyMethodSharedPtr method_{};
   Api::Api& api_;
   bssl::UniquePtr<EVP_PKEY> pkey_;
-  enum KeyType key_type_;
+  enum KeyType key_type_{KeyType::Rsa};
 
   ThreadLocal::TypedSlotPtr<ThreadLocalData> tls_;
 


### PR DESCRIPTION
Commit Message: cryptomb: initialize key type field
Additional Description:
For passing the coverity test.
Risk Level: low

