### PR TITLE
Fix the wrong server response match for pg upstream tls

### DIFF
--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -440,7 +440,8 @@ Decoder::Result DecoderImpl::onDataInNegotiating(Buffer::Instance& data, bool fr
 
   // This should be reply from the server indicating if it accepted
   // request to use SSL. It is only one character long packet, where
-  // 'S' means use SSL, 'E' means do not use.
+  // 'S' means use SSL, 'N' means do not use.
+  // See details in https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-SSL
 
   // Indicate to the filter, the response and give the initial
   // packet temporarily buffered to be sent upstream.
@@ -451,7 +452,7 @@ Decoder::Result DecoderImpl::onDataInNegotiating(Buffer::Instance& data, bool fr
     if (c == 'S') {
       upstreamSSL = true;
     } else {
-      if (c != 'E') {
+      if (c != 'N') {
         state_ = State::OutOfSyncState;
       }
     }

--- a/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
@@ -650,7 +650,7 @@ TEST_P(PostgresProxyUpstreamSSLTest, UpstreamSSLEnabled) {
   ASSERT_THAT(decoder_->state(), DecoderImpl::State::NegotiatingUpstreamSSL);
 
   // Simulate various responses from the upstream server.
-  // Only "S" and "E" are valid responses.
+  // Only "S" and "N" are valid responses.
   data_.add(std::get<0>(GetParam()));
 
   EXPECT_CALL(callbacks_, encryptUpstream(std::get<1>(GetParam()), testing::_));
@@ -665,7 +665,7 @@ INSTANTIATE_TEST_SUITE_P(BackendEncryptedMessagesTests, PostgresProxyUpstreamSSL
                              // Correct response from the server (encrypt).
                              std::make_tuple("S", true, DecoderImpl::State::InitState),
                              // Correct response from the server (do not encrypt).
-                             std::make_tuple("E", false, DecoderImpl::State::InitState),
+                             std::make_tuple("N", false, DecoderImpl::State::InitState),
                              // Incorrect response from the server. Move to out-of-sync state.
                              std::make_tuple("W", false, DecoderImpl::State::OutOfSyncState),
                              std::make_tuple("WRONG", false, DecoderImpl::State::OutOfSyncState)));

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -465,8 +465,8 @@ TEST_P(UpstreamSSLRequirePostgresIntegrationTest, ServerDeniesSSLTest) {
   ASSERT_EQ(80877103, upstream_data.peekBEInt<uint32_t>(4));
   upstream_data.drain(upstream_data.length());
 
-  // Reply to Envoy with 'E' (SSL not allowed).
-  upstream_data.add("E");
+  // Reply to Envoy with 'N' (SSL not allowed).
+  upstream_data.add("N");
   ASSERT_TRUE(fake_upstream_connection_->write(upstream_data.toString()));
   config_factory_.proceed_sync_.Notify();
 


### PR DESCRIPTION
In [this doc](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.6.7.12) of PostgreSQL, section [55.2.10.](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-SSL) outlines what is sent from server upon requesting for SSL- 

> The server then responds with a single byte containing S or N, indicating that it is willing or unwilling to perform SSL, respectively.

Current postgres filter matches 'E' instead of 'N' what was fixed in this PR. 

Commit Message:
Additional Description: 
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Fixes commit #23990